### PR TITLE
Fix countdown timer + add 8-bit hero animation

### DIFF
--- a/webinar_site/countdown.py
+++ b/webinar_site/countdown.py
@@ -30,7 +30,7 @@ def calculate_countdown(event_datetime, now=None):
         return {"days": 0, "hours": 0, "minutes": 0, "seconds": 0, "passed": True}
 
     days = total_seconds // 86400
-    hours = total_seconds // 3600  # BUG: should be (total_seconds % 86400) // 3600
+    hours = (total_seconds % 86400) // 3600
     minutes = (total_seconds % 3600) // 60
     seconds = total_seconds % 60
 

--- a/webinar_site/static/animation.css
+++ b/webinar_site/static/animation.css
@@ -1,10 +1,421 @@
-/* Hero Animation Styles
-   =====================
-   This file contains the hero section animation.
-   Use /create-animation to generate a custom 8-bit pixel art character
-   based on a photo of the presenter. */
+/* 8-Bit Pixel Art Side-Scroller Animation
+   ========================================
+   Custom pixel art character based on presenter photo.
+   Super Mario-style scene with scrolling ground, hills, and clouds. */
 
-/* Placeholder styles — replaced by /create-animation skill */
+/* === SCENE CONTAINER === */
 .pixel-character-scene {
-  display: none;
+  position: relative;
+  width: 100%;
+  height: 160px;
+  overflow: hidden;
+  margin: 2rem 0;
+}
+
+/* === GROUND — Coral brick pattern === */
+.scene-ground {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 24px;
+  background-color: #d97757;
+  background-image:
+    repeating-linear-gradient(
+      90deg,
+      transparent 0px,
+      transparent 23px,
+      #1a1a1a 23px,
+      #1a1a1a 24px
+    ),
+    repeating-linear-gradient(
+      0deg,
+      transparent 0px,
+      transparent 11px,
+      #1a1a1a 11px,
+      #1a1a1a 12px
+    );
+  background-size: 24px 12px;
+  animation: scroll-ground 1.5s linear infinite;
+}
+
+.scene-ground::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: -24px;
+  width: calc(100% + 48px);
+  height: 12px;
+  background-color: #c84400;
+  background-image:
+    repeating-linear-gradient(
+      90deg,
+      transparent 0px,
+      transparent 23px,
+      #1a1a1a 23px,
+      #1a1a1a 24px
+    ),
+    repeating-linear-gradient(
+      0deg,
+      transparent 0px,
+      transparent 11px,
+      #1a1a1a 11px,
+      #1a1a1a 12px
+    );
+  background-size: 24px 12px;
+  background-position: 12px 0;
+  animation: scroll-ground 1.5s linear infinite;
+}
+
+@keyframes scroll-ground {
+  from { background-position-x: 0px; }
+  to { background-position-x: -24px; }
+}
+
+/* === HILLS — Stepped pixel pyramids === */
+.scene-hill {
+  position: absolute;
+  bottom: 24px;
+  width: 1px;
+  height: 1px;
+  background: transparent;
+}
+
+.hill-1 {
+  left: 15%;
+  transform: scale(7);
+  transform-origin: bottom center;
+  box-shadow:
+    0px 0px 0 #5ab847,
+    -1px 0px 0 #5ab847,
+    1px 0px 0 #5ab847,
+    -2px 0px 0 #4a9a3a,
+    2px 0px 0 #4a9a3a,
+    -3px 0px 0 #3a8a2a,
+    3px 0px 0 #3a8a2a,
+    0px -1px 0 #5ab847,
+    -1px -1px 0 #5ab847,
+    1px -1px 0 #5ab847,
+    -2px -1px 0 #4a9a3a,
+    2px -1px 0 #4a9a3a,
+    0px -2px 0 #5ab847,
+    -1px -2px 0 #5ab847,
+    1px -2px 0 #5ab847,
+    0px -3px 0 #5ab847,
+    -1px -3px 0 #4a9a3a,
+    1px -3px 0 #4a9a3a,
+    0px -4px 0 #5ab847;
+  animation: scroll-hill 12s linear infinite;
+}
+
+.hill-2 {
+  left: 65%;
+  transform: scale(5);
+  transform-origin: bottom center;
+  box-shadow:
+    0px 0px 0 #5ab847,
+    -1px 0px 0 #5ab847,
+    1px 0px 0 #5ab847,
+    -2px 0px 0 #4a9a3a,
+    2px 0px 0 #4a9a3a,
+    0px -1px 0 #5ab847,
+    -1px -1px 0 #5ab847,
+    1px -1px 0 #5ab847,
+    0px -2px 0 #5ab847,
+    -1px -2px 0 #4a9a3a,
+    0px -3px 0 #5ab847;
+  animation: scroll-hill 12s linear infinite;
+  animation-delay: -4s;
+}
+
+@keyframes scroll-hill {
+  from { transform-origin: bottom center; left: 110%; }
+  to { transform-origin: bottom center; left: -20%; }
+}
+
+/* === CLOUDS — Puffy white pixel sprites === */
+.scene-cloud {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  background: transparent;
+  transform: scale(3);
+  transform-origin: top left;
+}
+
+.cloud-1 {
+  top: 15px;
+  box-shadow:
+    1px 0px 0 #fff,
+    2px 0px 0 #fff,
+    3px 0px 0 #fff,
+    4px 0px 0 #fff,
+    0px 1px 0 #fff,
+    1px 1px 0 #fff,
+    2px 1px 0 #fff,
+    3px 1px 0 #fff,
+    4px 1px 0 #fff,
+    5px 1px 0 #fff,
+    1px 2px 0 #eee,
+    2px 2px 0 #eee,
+    3px 2px 0 #eee,
+    4px 2px 0 #eee;
+  animation: float-cloud 10s linear infinite;
+}
+
+.cloud-2 {
+  top: 30px;
+  box-shadow:
+    1px 0px 0 #fff,
+    2px 0px 0 #fff,
+    3px 0px 0 #fff,
+    0px 1px 0 #fff,
+    1px 1px 0 #fff,
+    2px 1px 0 #fff,
+    3px 1px 0 #fff,
+    4px 1px 0 #fff,
+    1px 2px 0 #eee,
+    2px 2px 0 #eee,
+    3px 2px 0 #eee;
+  animation: float-cloud 15s linear infinite;
+  animation-delay: -5s;
+}
+
+.cloud-3 {
+  top: 8px;
+  box-shadow:
+    2px 0px 0 #fff,
+    3px 0px 0 #fff,
+    4px 0px 0 #fff,
+    5px 0px 0 #fff,
+    1px 1px 0 #fff,
+    2px 1px 0 #fff,
+    3px 1px 0 #fff,
+    4px 1px 0 #fff,
+    5px 1px 0 #fff,
+    6px 1px 0 #fff,
+    0px 2px 0 #fff,
+    1px 2px 0 #fff,
+    2px 2px 0 #fff,
+    3px 2px 0 #fff,
+    4px 2px 0 #fff,
+    5px 2px 0 #fff,
+    6px 2px 0 #fff,
+    1px 3px 0 #eee,
+    2px 3px 0 #eee,
+    3px 3px 0 #eee,
+    4px 3px 0 #eee,
+    5px 3px 0 #eee;
+  animation: float-cloud 20s linear infinite;
+  animation-delay: -8s;
+}
+
+@keyframes float-cloud {
+  from { left: 110%; }
+  to { left: -40px; }
+}
+
+/* === RUNNER CONTAINER === */
+.scene-runner {
+  position: absolute;
+  bottom: 24px;
+  left: 25%;
+  width: 1px;
+  height: 1px;
+  animation: runner-bounce 0.25s ease-in-out infinite alternate;
+  z-index: 10;
+}
+
+@keyframes runner-bounce {
+  0% { transform: translateY(0); }
+  100% { transform: translateY(-4px); }
+}
+
+/* === SPEECH BUBBLE === */
+.speech-bubble {
+  position: absolute;
+  top: -96px;
+  left: -10px;
+  background: #fff;
+  border: 2px solid #1a1a1a;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-family: monospace;
+  font-size: 11px;
+  font-weight: bold;
+  color: #1a1a1a;
+  white-space: nowrap;
+  z-index: 20;
+}
+
+.speech-bubble::after {
+  content: '';
+  position: absolute;
+  bottom: -8px;
+  left: 20px;
+  width: 0;
+  height: 0;
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-top: 8px solid #1a1a1a;
+}
+
+.speech-bubble::before {
+  content: '';
+  position: absolute;
+  bottom: -6px;
+  left: 21px;
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 6px solid #fff;
+  z-index: 1;
+}
+
+/* === CHARACTER PIXEL ART ===
+   Chibi style: big head, tiny body, stubby legs.
+   Side profile facing RIGHT, holding laptop.
+   Based on: blonde hair, fair skin, blue glasses, black turtleneck.
+   Grid: ~12 wide x 14 tall at scale(5). */
+
+.runner-body {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 1px;
+  height: 1px;
+  background: transparent;
+  transform: scale(5);
+  transform-origin: bottom left;
+  box-shadow:
+    /* Row -12: top of head (hair) */
+    3px -12px 0 #e8c84a,
+    4px -12px 0 #e8c84a,
+    5px -12px 0 #e8c84a,
+    6px -12px 0 #d4b43e,
+
+    /* Row -11: hair wider */
+    2px -11px 0 #e8c84a,
+    3px -11px 0 #e8c84a,
+    4px -11px 0 #e8c84a,
+    5px -11px 0 #e8c84a,
+    6px -11px 0 #e8c84a,
+    7px -11px 0 #d4b43e,
+
+    /* Row -10: hair + forehead */
+    1px -10px 0 #d4b43e,
+    2px -10px 0 #e8c84a,
+    3px -10px 0 #e8c84a,
+    4px -10px 0 #fdd0a0,
+    5px -10px 0 #fdd0a0,
+    6px -10px 0 #fdd0a0,
+    7px -10px 0 #e8c84a,
+
+    /* Row -9: hair + glasses + eye */
+    1px -9px 0 #d4b43e,
+    2px -9px 0 #e8c84a,
+    3px -9px 0 #4466aa,
+    4px -9px 0 #ffffff,
+    5px -9px 0 #334455,
+    6px -9px 0 #4466aa,
+    7px -9px 0 #fdd0a0,
+
+    /* Row -8: hair + face */
+    1px -8px 0 #d4b43e,
+    2px -8px 0 #e8c84a,
+    3px -8px 0 #fdd0a0,
+    4px -8px 0 #fdd0a0,
+    5px -8px 0 #fdd0a0,
+    6px -8px 0 #fdd0a0,
+    7px -8px 0 #fdd0a0,
+
+    /* Row -7: hair + cheek + smile */
+    1px -7px 0 #d4b43e,
+    2px -7px 0 #e8c84a,
+    3px -7px 0 #fdd0a0,
+    4px -7px 0 #ff9999,
+    5px -7px 0 #cc8877,
+    6px -7px 0 #fdd0a0,
+
+    /* Row -6: hair + chin */
+    1px -6px 0 #d4b43e,
+    2px -6px 0 #e8c84a,
+    3px -6px 0 #fdd0a0,
+    4px -6px 0 #fdd0a0,
+    5px -6px 0 #fdd0a0,
+
+    /* Row -5: hair flowing + neck (black turtleneck) */
+    1px -5px 0 #d4b43e,
+    2px -5px 0 #e8c84a,
+    4px -5px 0 #2a2a2a,
+    5px -5px 0 #2a2a2a,
+
+    /* Row -4: hair + body + arm reaching for laptop */
+    1px -4px 0 #e8c84a,
+    3px -4px 0 #2a2a2a,
+    4px -4px 0 #2a2a2a,
+    5px -4px 0 #2a2a2a,
+    6px -4px 0 #2a2a2a,
+    7px -4px 0 #888888,
+    8px -4px 0 #888888,
+
+    /* Row -3: body + laptop */
+    3px -3px 0 #1a1a1a,
+    4px -3px 0 #2a2a2a,
+    5px -3px 0 #2a2a2a,
+    6px -3px 0 #666666,
+    7px -3px 0 #777777,
+    8px -3px 0 #666666,
+
+    /* Row -2: hips */
+    3px -2px 0 #2a2a2a,
+    4px -2px 0 #2a2a2a,
+    5px -2px 0 #2a2a2a;
+}
+
+/* === LEG ANIMATIONS === */
+/* Frame 1: legs spread (running stride) */
+.runner-legs.leg-frame-1 {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 1px;
+  height: 1px;
+  background: transparent;
+  transform: scale(5);
+  transform-origin: bottom left;
+  box-shadow:
+    /* Left leg forward */
+    3px -1px 0 #2a2a2a,
+    2px 0px 0 #333333,
+    /* Right leg back */
+    5px -1px 0 #2a2a2a,
+    6px 0px 0 #333333;
+  animation: leg-toggle 0.25s steps(1) infinite;
+}
+
+/* Frame 2: legs other position */
+.runner-legs.leg-frame-2 {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 1px;
+  height: 1px;
+  background: transparent;
+  transform: scale(5);
+  transform-origin: bottom left;
+  box-shadow:
+    /* Legs closer together */
+    4px -1px 0 #2a2a2a,
+    3px 0px 0 #333333,
+    5px -1px 0 #2a2a2a,
+    5px 0px 0 #333333;
+  opacity: 0;
+  animation: leg-toggle 0.25s steps(1) infinite reverse;
+}
+
+@keyframes leg-toggle {
+  0% { opacity: 1; }
+  50% { opacity: 0; }
 }

--- a/webinar_site/templates.py
+++ b/webinar_site/templates.py
@@ -74,6 +74,22 @@ def render_landing_page(event, speakers, countdown):
                     </div>
                 </div>
 
+                <!-- 8-Bit Pixel Art Animation -->
+                <div class="pixel-character-scene">
+                    <div class="scene-cloud cloud-1"></div>
+                    <div class="scene-cloud cloud-2"></div>
+                    <div class="scene-cloud cloud-3"></div>
+                    <div class="scene-hill hill-1"></div>
+                    <div class="scene-hill hill-2"></div>
+                    <div class="scene-runner">
+                        <div class="speech-bubble">let claude cook</div>
+                        <div class="runner-body"></div>
+                        <div class="runner-legs leg-frame-1"></div>
+                        <div class="runner-legs leg-frame-2"></div>
+                    </div>
+                    <div class="scene-ground"></div>
+                </div>
+
                 <!-- Speakers -->
                 <div class="featuring">
                     <h2 class="section-heading-sm">Featuring</h2>


### PR DESCRIPTION
## Summary
- **Fix countdown hours bug**: The `calculate_countdown` function was computing `total_seconds // 3600` for hours instead of `(total_seconds % 86400) // 3600`, causing hours to exceed 23 when the event was multiple days away. Closes #1.
- **Add 8-bit pixel art hero animation**: A Super Mario-style side-scroller between the countdown and "Featuring" sections — scrolling coral brick ground, parallax green hills, floating clouds, and a chibi pixel art character (blonde hair, blue glasses, black turtleneck) running with a laptop and a "let claude cook" speech bubble.

## Test plan
- [ ] Verify countdown shows correct hours (e.g. 2 days 5 hours, not 2 days 53 hours)
- [ ] Run `python3 -m pytest tests/ -v` to confirm countdown unit tests pass
- [ ] Open http://localhost:8000 and confirm the pixel art animation renders between countdown and speakers
- [ ] Check that the terminal visual still appears in its original position below the speakers

🤖 Generated with [Claude Code](https://claude.com/claude-code)