### PR TITLE
Fix countdown timer + add 8-bit hero animation

### DIFF
--- a/webinar_site/static/animation.css
+++ b/webinar_site/static/animation.css
@@ -1,139 +1,19 @@
-/* 8-Bit Pixel Art Side-Scroller Animation
-   ========================================
-   Custom pixel art character based on presenter photo.
-   Super Mario-style scene with scrolling ground, hills, and clouds. */
+/* Hero 8-Bit Pixel Art Side-Scroller Animation
+   =============================================
+   Super Mario-style scene with chibi pixel character
+   Based on: Caroline — blonde hair, blue glasses, black turtleneck */
 
-/* === SCENE CONTAINER === */
+/* === Scene Container === */
 .pixel-character-scene {
   position: relative;
   width: 100%;
   height: 160px;
   overflow: hidden;
   margin: 2rem 0;
+  /* transparent — page cream shows through as sky */
 }
 
-/* === GROUND — Coral brick pattern === */
-.scene-ground {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 24px;
-  background-color: #d97757;
-  background-image:
-    repeating-linear-gradient(
-      90deg,
-      transparent 0px,
-      transparent 23px,
-      #1a1a1a 23px,
-      #1a1a1a 24px
-    ),
-    repeating-linear-gradient(
-      0deg,
-      transparent 0px,
-      transparent 11px,
-      #1a1a1a 11px,
-      #1a1a1a 12px
-    );
-  background-size: 24px 12px;
-  animation: scroll-ground 1.5s linear infinite;
-}
-
-.scene-ground::after {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: -24px;
-  width: calc(100% + 48px);
-  height: 12px;
-  background-color: #c84400;
-  background-image:
-    repeating-linear-gradient(
-      90deg,
-      transparent 0px,
-      transparent 23px,
-      #1a1a1a 23px,
-      #1a1a1a 24px
-    ),
-    repeating-linear-gradient(
-      0deg,
-      transparent 0px,
-      transparent 11px,
-      #1a1a1a 11px,
-      #1a1a1a 12px
-    );
-  background-size: 24px 12px;
-  background-position: 12px 0;
-  animation: scroll-ground 1.5s linear infinite;
-}
-
-@keyframes scroll-ground {
-  from { background-position-x: 0px; }
-  to { background-position-x: -24px; }
-}
-
-/* === HILLS — Stepped pixel pyramids === */
-.scene-hill {
-  position: absolute;
-  bottom: 24px;
-  width: 1px;
-  height: 1px;
-  background: transparent;
-}
-
-.hill-1 {
-  left: 15%;
-  transform: scale(7);
-  transform-origin: bottom center;
-  box-shadow:
-    0px 0px 0 #5ab847,
-    -1px 0px 0 #5ab847,
-    1px 0px 0 #5ab847,
-    -2px 0px 0 #4a9a3a,
-    2px 0px 0 #4a9a3a,
-    -3px 0px 0 #3a8a2a,
-    3px 0px 0 #3a8a2a,
-    0px -1px 0 #5ab847,
-    -1px -1px 0 #5ab847,
-    1px -1px 0 #5ab847,
-    -2px -1px 0 #4a9a3a,
-    2px -1px 0 #4a9a3a,
-    0px -2px 0 #5ab847,
-    -1px -2px 0 #5ab847,
-    1px -2px 0 #5ab847,
-    0px -3px 0 #5ab847,
-    -1px -3px 0 #4a9a3a,
-    1px -3px 0 #4a9a3a,
-    0px -4px 0 #5ab847;
-  animation: scroll-hill 12s linear infinite;
-}
-
-.hill-2 {
-  left: 65%;
-  transform: scale(5);
-  transform-origin: bottom center;
-  box-shadow:
-    0px 0px 0 #5ab847,
-    -1px 0px 0 #5ab847,
-    1px 0px 0 #5ab847,
-    -2px 0px 0 #4a9a3a,
-    2px 0px 0 #4a9a3a,
-    0px -1px 0 #5ab847,
-    -1px -1px 0 #5ab847,
-    1px -1px 0 #5ab847,
-    0px -2px 0 #5ab847,
-    -1px -2px 0 #4a9a3a,
-    0px -3px 0 #5ab847;
-  animation: scroll-hill 12s linear infinite;
-  animation-delay: -4s;
-}
-
-@keyframes scroll-hill {
-  from { transform-origin: bottom center; left: 110%; }
-  to { transform-origin: bottom center; left: -20%; }
-}
-
-/* === CLOUDS — Puffy white pixel sprites === */
+/* === Clouds === */
 .scene-cloud {
   position: absolute;
   width: 1px;
@@ -144,78 +24,147 @@
 }
 
 .cloud-1 {
-  top: 15px;
+  top: 12px;
+  animation: float-cloud 15s linear infinite;
   box-shadow:
-    1px 0px 0 #fff,
-    2px 0px 0 #fff,
-    3px 0px 0 #fff,
-    4px 0px 0 #fff,
-    0px 1px 0 #fff,
-    1px 1px 0 #fff,
-    2px 1px 0 #fff,
-    3px 1px 0 #fff,
-    4px 1px 0 #fff,
-    5px 1px 0 #fff,
-    1px 2px 0 #eee,
-    2px 2px 0 #eee,
-    3px 2px 0 #eee,
-    4px 2px 0 #eee;
-  animation: float-cloud 10s linear infinite;
+    /* puffy cloud shape ~8x4 */
+    2px 0 0 #fff, 3px 0 0 #fff, 4px 0 0 #fff, 5px 0 0 #fff,
+    1px 1px 0 #fff, 2px 1px 0 #fff, 3px 1px 0 #fff, 4px 1px 0 #fff, 5px 1px 0 #fff, 6px 1px 0 #fff,
+    1px 2px 0 #fff, 2px 2px 0 #fff, 3px 2px 0 #fff, 4px 2px 0 #fff, 5px 2px 0 #fff, 6px 2px 0 #fff,
+    2px 3px 0 #fff, 3px 3px 0 #fff, 4px 3px 0 #fff, 5px 3px 0 #fff;
 }
 
 .cloud-2 {
-  top: 30px;
+  top: 28px;
+  animation: float-cloud 20s linear infinite;
+  animation-delay: -7s;
   box-shadow:
-    1px 0px 0 #fff,
-    2px 0px 0 #fff,
-    3px 0px 0 #fff,
-    0px 1px 0 #fff,
-    1px 1px 0 #fff,
-    2px 1px 0 #fff,
-    3px 1px 0 #fff,
-    4px 1px 0 #fff,
-    1px 2px 0 #eee,
-    2px 2px 0 #eee,
-    3px 2px 0 #eee;
-  animation: float-cloud 15s linear infinite;
-  animation-delay: -5s;
+    1px 0 0 #fff, 2px 0 0 #fff, 3px 0 0 #fff,
+    0px 1px 0 #fff, 1px 1px 0 #fff, 2px 1px 0 #fff, 3px 1px 0 #fff, 4px 1px 0 #fff,
+    0px 2px 0 #fff, 1px 2px 0 #fff, 2px 2px 0 #fff, 3px 2px 0 #fff, 4px 2px 0 #fff,
+    1px 3px 0 #fff, 2px 3px 0 #fff, 3px 3px 0 #fff;
 }
 
 .cloud-3 {
   top: 8px;
+  animation: float-cloud 12s linear infinite;
+  animation-delay: -3s;
   box-shadow:
-    2px 0px 0 #fff,
-    3px 0px 0 #fff,
-    4px 0px 0 #fff,
-    5px 0px 0 #fff,
-    1px 1px 0 #fff,
-    2px 1px 0 #fff,
-    3px 1px 0 #fff,
-    4px 1px 0 #fff,
-    5px 1px 0 #fff,
-    6px 1px 0 #fff,
-    0px 2px 0 #fff,
-    1px 2px 0 #fff,
-    2px 2px 0 #fff,
-    3px 2px 0 #fff,
-    4px 2px 0 #fff,
-    5px 2px 0 #fff,
-    6px 2px 0 #fff,
-    1px 3px 0 #eee,
-    2px 3px 0 #eee,
-    3px 3px 0 #eee,
-    4px 3px 0 #eee,
-    5px 3px 0 #eee;
-  animation: float-cloud 20s linear infinite;
-  animation-delay: -8s;
+    2px 0 0 #fff, 3px 0 0 #fff, 4px 0 0 #fff,
+    1px 1px 0 #fff, 2px 1px 0 #fff, 3px 1px 0 #fff, 4px 1px 0 #fff, 5px 1px 0 #fff,
+    1px 2px 0 #fff, 2px 2px 0 #fff, 3px 2px 0 #fff, 4px 2px 0 #fff, 5px 2px 0 #fff,
+    2px 3px 0 #fff, 3px 3px 0 #fff, 4px 3px 0 #fff;
 }
 
 @keyframes float-cloud {
-  from { left: 110%; }
-  to { left: -40px; }
+  from { transform: scale(3) translateX(250px); }
+  to   { transform: scale(3) translateX(-80px); }
 }
 
-/* === RUNNER CONTAINER === */
+/* === Hills (stepped pyramids, negative y = upward) === */
+.scene-hill {
+  position: absolute;
+  bottom: 24px;
+  width: 1px;
+  height: 1px;
+  background: transparent;
+  animation: scroll-hill 18s linear infinite;
+}
+
+.hill-1 {
+  transform: scale(7);
+  transform-origin: bottom left;
+  box-shadow:
+    /* wide base */
+    0px -1px 0 #3a8a2a, 1px -1px 0 #3a8a2a, 2px -1px 0 #3a8a2a, 3px -1px 0 #3a8a2a,
+    4px -1px 0 #3a8a2a, 5px -1px 0 #3a8a2a, 6px -1px 0 #3a8a2a, 7px -1px 0 #3a8a2a,
+    8px -1px 0 #3a8a2a, 9px -1px 0 #3a8a2a,
+    /* second row */
+    1px -2px 0 #4a9a3a, 2px -2px 0 #4a9a3a, 3px -2px 0 #4a9a3a, 4px -2px 0 #4a9a3a,
+    5px -2px 0 #4a9a3a, 6px -2px 0 #4a9a3a, 7px -2px 0 #4a9a3a, 8px -2px 0 #4a9a3a,
+    /* third row */
+    2px -3px 0 #4a9a3a, 3px -3px 0 #4a9a3a, 4px -3px 0 #4a9a3a,
+    5px -3px 0 #4a9a3a, 6px -3px 0 #4a9a3a, 7px -3px 0 #4a9a3a,
+    /* fourth row */
+    3px -4px 0 #5ab847, 4px -4px 0 #5ab847, 5px -4px 0 #5ab847, 6px -4px 0 #5ab847,
+    /* peak */
+    4px -5px 0 #5ab847, 5px -5px 0 #5ab847;
+}
+
+.hill-2 {
+  transform: scale(5);
+  transform-origin: bottom left;
+  animation-delay: -9s;
+  box-shadow:
+    /* base */
+    0px -1px 0 #3a8a2a, 1px -1px 0 #3a8a2a, 2px -1px 0 #3a8a2a, 3px -1px 0 #3a8a2a,
+    4px -1px 0 #3a8a2a, 5px -1px 0 #3a8a2a, 6px -1px 0 #3a8a2a,
+    /* second row */
+    1px -2px 0 #4a9a3a, 2px -2px 0 #4a9a3a, 3px -2px 0 #4a9a3a,
+    4px -2px 0 #4a9a3a, 5px -2px 0 #4a9a3a,
+    /* third row */
+    2px -3px 0 #5ab847, 3px -3px 0 #5ab847, 4px -3px 0 #5ab847;
+}
+
+@keyframes scroll-hill {
+  from { left: calc(100% + 100px); }
+  to   { left: -200px; }
+}
+
+/* === Ground (coral bricks) === */
+.scene-ground {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 24px;
+  background-color: #d97757;
+  background-image:
+    /* horizontal mortar lines */
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0px, transparent 10px,
+      #1a1a1a 10px, #1a1a1a 12px
+    ),
+    /* vertical mortar lines (top row) */
+    repeating-linear-gradient(
+      to right,
+      #1a1a1a 0px, #1a1a1a 2px,
+      transparent 2px, transparent 24px
+    );
+  background-size: 24px 12px, 24px 12px;
+  animation: scroll-ground 2s linear infinite;
+}
+
+.scene-ground::after {
+  content: '';
+  position: absolute;
+  top: 12px;
+  left: -12px;
+  width: calc(100% + 24px);
+  height: 12px;
+  background-color: #d97757;
+  background-image:
+    repeating-linear-gradient(
+      to bottom,
+      transparent 0px, transparent 10px,
+      #1a1a1a 10px, #1a1a1a 12px
+    ),
+    repeating-linear-gradient(
+      to right,
+      #1a1a1a 0px, #1a1a1a 2px,
+      transparent 2px, transparent 24px
+    );
+  background-size: 24px 12px, 24px 12px;
+  animation: scroll-ground 2s linear infinite;
+}
+
+@keyframes scroll-ground {
+  from { background-position: 0 0; }
+  to   { background-position: -24px 0; }
+}
+
+/* === Runner Container === */
 .scene-runner {
   position: absolute;
   bottom: 24px;
@@ -223,36 +172,35 @@
   width: 1px;
   height: 1px;
   animation: runner-bounce 0.25s ease-in-out infinite alternate;
-  z-index: 10;
 }
 
 @keyframes runner-bounce {
-  0% { transform: translateY(0); }
-  100% { transform: translateY(-4px); }
+  from { transform: translateY(0); }
+  to   { transform: translateY(-4px); }
 }
 
-/* === SPEECH BUBBLE === */
+/* === Speech Bubble === */
 .speech-bubble {
   position: absolute;
-  top: -96px;
+  top: -95px;
   left: -10px;
   background: #fff;
-  border: 2px solid #1a1a1a;
-  border-radius: 4px;
-  padding: 4px 8px;
+  color: #1a1a1a;
   font-family: monospace;
   font-size: 11px;
   font-weight: bold;
-  color: #1a1a1a;
+  padding: 4px 8px;
+  border: 2px solid #1a1a1a;
+  border-radius: 4px;
   white-space: nowrap;
-  z-index: 20;
+  z-index: 10;
 }
 
 .speech-bubble::after {
   content: '';
   position: absolute;
   bottom: -8px;
-  left: 20px;
+  left: 16px;
   width: 0;
   height: 0;
   border-left: 6px solid transparent;
@@ -263,8 +211,8 @@
 .speech-bubble::before {
   content: '';
   position: absolute;
-  bottom: -6px;
-  left: 21px;
+  bottom: -5px;
+  left: 17px;
   width: 0;
   height: 0;
   border-left: 5px solid transparent;
@@ -273,149 +221,107 @@
   z-index: 1;
 }
 
-/* === CHARACTER PIXEL ART ===
-   Chibi style: big head, tiny body, stubby legs.
-   Side profile facing RIGHT, holding laptop.
-   Based on: blonde hair, fair skin, blue glasses, black turtleneck.
-   Grid: ~12 wide x 14 tall at scale(5). */
+/* === Character Body (pixel art via box-shadow) ===
+   Chibi side profile facing RIGHT
+   ~12 wide x 14 tall at scale(5)
+   Caroline: blonde hair, fair skin, blue glasses, black turtleneck, holding laptop */
 
 .runner-body {
   position: absolute;
-  bottom: 0;
-  left: 0;
   width: 1px;
   height: 1px;
   background: transparent;
   transform: scale(5);
   transform-origin: bottom left;
   box-shadow:
-    /* Row -12: top of head (hair) */
-    3px -12px 0 #e8c84a,
-    4px -12px 0 #e8c84a,
-    5px -12px 0 #e8c84a,
-    6px -12px 0 #d4b43e,
+    /* === HAIR TOP (row y=-14) === */
+    3px -14px 0 #e0a830, 4px -14px 0 #e0a830, 5px -14px 0 #e0a830, 6px -14px 0 #e0a830,
 
-    /* Row -11: hair wider */
-    2px -11px 0 #e8c84a,
-    3px -11px 0 #e8c84a,
-    4px -11px 0 #e8c84a,
-    5px -11px 0 #e8c84a,
-    6px -11px 0 #e8c84a,
-    7px -11px 0 #d4b43e,
+    /* === HAIR (row y=-13) === */
+    2px -13px 0 #e0a830, 3px -13px 0 #e0a830, 4px -13px 0 #e0a830,
+    5px -13px 0 #e0a830, 6px -13px 0 #e0a830, 7px -13px 0 #e0a830,
 
-    /* Row -10: hair + forehead */
-    1px -10px 0 #d4b43e,
-    2px -10px 0 #e8c84a,
-    3px -10px 0 #e8c84a,
-    4px -10px 0 #fdd0a0,
-    5px -10px 0 #fdd0a0,
-    6px -10px 0 #fdd0a0,
-    7px -10px 0 #e8c84a,
+    /* === HAIR WIDE (row y=-12) === */
+    1px -12px 0 #e0a830, 2px -12px 0 #e0a830, 3px -12px 0 #e0a830, 4px -12px 0 #e0a830,
+    5px -12px 0 #e0a830, 6px -12px 0 #d4a020, 7px -12px 0 #d4a020, 8px -12px 0 #e0a830,
 
-    /* Row -9: hair + glasses + eye */
-    1px -9px 0 #d4b43e,
-    2px -9px 0 #e8c84a,
-    3px -9px 0 #4466aa,
-    4px -9px 0 #ffffff,
-    5px -9px 0 #334455,
-    6px -9px 0 #4466aa,
-    7px -9px 0 #fdd0a0,
+    /* === FOREHEAD + GLASSES TOP (row y=-11) === */
+    1px -11px 0 #e0a830, 2px -11px 0 #e0a830, 3px -11px 0 #e0a830,
+    4px -11px 0 #fdd5b4, 5px -11px 0 #fdd5b4,
+    6px -11px 0 #4466aa, 7px -11px 0 #4466aa, 8px -11px 0 #4466aa,
 
-    /* Row -8: hair + face */
-    1px -8px 0 #d4b43e,
-    2px -8px 0 #e8c84a,
-    3px -8px 0 #fdd0a0,
-    4px -8px 0 #fdd0a0,
-    5px -8px 0 #fdd0a0,
-    6px -8px 0 #fdd0a0,
-    7px -8px 0 #fdd0a0,
+    /* === EYE ROW (row y=-10) === */
+    0px -10px 0 #e0a830, 1px -10px 0 #e0a830, 2px -10px 0 #e0a830,
+    3px -10px 0 #fdd5b4, 4px -10px 0 #fdd5b4,
+    5px -10px 0 #ffffff, 6px -10px 0 #223344,
+    7px -10px 0 #4466aa,
+    8px -10px 0 #fdd5b4,
 
-    /* Row -7: hair + cheek + smile */
-    1px -7px 0 #d4b43e,
-    2px -7px 0 #e8c84a,
-    3px -7px 0 #fdd0a0,
-    4px -7px 0 #ff9999,
-    5px -7px 0 #cc8877,
-    6px -7px 0 #fdd0a0,
+    /* === CHEEK ROW (row y=-9) === */
+    0px -9px 0 #e0a830, 1px -9px 0 #e0a830,
+    2px -9px 0 #fdd5b4, 3px -9px 0 #fdd5b4, 4px -9px 0 #fdd5b4,
+    5px -9px 0 #fdd5b4, 6px -9px 0 #fdd5b4,
+    7px -9px 0 #ff9999,
 
-    /* Row -6: hair + chin */
-    1px -6px 0 #d4b43e,
-    2px -6px 0 #e8c84a,
-    3px -6px 0 #fdd0a0,
-    4px -6px 0 #fdd0a0,
-    5px -6px 0 #fdd0a0,
+    /* === MOUTH ROW (row y=-8) === */
+    0px -8px 0 #d4a020, 1px -8px 0 #e0a830,
+    2px -8px 0 #e0a830, 3px -8px 0 #fdd5b4, 4px -8px 0 #fdd5b4,
+    5px -8px 0 #dd8877, 6px -8px 0 #fdd5b4,
 
-    /* Row -5: hair flowing + neck (black turtleneck) */
-    1px -5px 0 #d4b43e,
-    2px -5px 0 #e8c84a,
-    4px -5px 0 #2a2a2a,
-    5px -5px 0 #2a2a2a,
+    /* === CHIN (row y=-7) === */
+    0px -7px 0 #d4a020, 1px -7px 0 #e0a830,
+    3px -7px 0 #fdd5b4, 4px -7px 0 #fdd5b4, 5px -7px 0 #fdd5b4,
 
-    /* Row -4: hair + body + arm reaching for laptop */
-    1px -4px 0 #e8c84a,
-    3px -4px 0 #2a2a2a,
-    4px -4px 0 #2a2a2a,
-    5px -4px 0 #2a2a2a,
-    6px -4px 0 #2a2a2a,
-    7px -4px 0 #888888,
-    8px -4px 0 #888888,
+    /* === NECK / TURTLENECK (row y=-6) === */
+    0px -6px 0 #d4a020, 1px -6px 0 #d4a020,
+    3px -6px 0 #2a2a2a, 4px -6px 0 #2a2a2a, 5px -6px 0 #2a2a2a,
 
-    /* Row -3: body + laptop */
-    3px -3px 0 #1a1a1a,
-    4px -3px 0 #2a2a2a,
-    5px -3px 0 #2a2a2a,
-    6px -3px 0 #666666,
-    7px -3px 0 #777777,
-    8px -3px 0 #666666,
+    /* === TURTLENECK SHOULDERS (row y=-5) === */
+    0px -5px 0 #d4a020,
+    2px -5px 0 #2a2a2a, 3px -5px 0 #2a2a2a, 4px -5px 0 #2a2a2a,
+    5px -5px 0 #2a2a2a, 6px -5px 0 #2a2a2a,
 
-    /* Row -2: hips */
-    3px -2px 0 #2a2a2a,
-    4px -2px 0 #2a2a2a,
-    5px -2px 0 #2a2a2a;
+    /* === TORSO + LAPTOP (row y=-4) === */
+    3px -4px 0 #2a2a2a, 4px -4px 0 #2a2a2a, 5px -4px 0 #2a2a2a,
+    6px -4px 0 #888888, 7px -4px 0 #888888, 8px -4px 0 #888888,
+
+    /* === TORSO + LAPTOP (row y=-3) === */
+    3px -3px 0 #333333, 4px -3px 0 #2a2a2a,
+    5px -3px 0 #666666, 6px -3px 0 #888888, 7px -3px 0 #888888,
+
+    /* === HIPS (row y=-2) === */
+    4px -2px 0 #2a2a2a, 5px -2px 0 #2a2a2a;
 }
 
-/* === LEG ANIMATIONS === */
-/* Frame 1: legs spread (running stride) */
+/* === Leg Frame 1 (stride: legs apart) === */
 .runner-legs.leg-frame-1 {
   position: absolute;
-  bottom: 0;
-  left: 0;
   width: 1px;
   height: 1px;
   background: transparent;
   transform: scale(5);
   transform-origin: bottom left;
-  box-shadow:
-    /* Left leg forward */
-    3px -1px 0 #2a2a2a,
-    2px 0px 0 #333333,
-    /* Right leg back */
-    5px -1px 0 #2a2a2a,
-    6px 0px 0 #333333;
   animation: leg-toggle 0.25s steps(1) infinite;
+  box-shadow:
+    3px -1px 0 #2a2a2a, 6px -1px 0 #2a2a2a;
 }
 
-/* Frame 2: legs other position */
+/* === Leg Frame 2 (stride: legs crossed) === */
 .runner-legs.leg-frame-2 {
   position: absolute;
-  bottom: 0;
-  left: 0;
   width: 1px;
   height: 1px;
   background: transparent;
   transform: scale(5);
   transform-origin: bottom left;
-  box-shadow:
-    /* Legs closer together */
-    4px -1px 0 #2a2a2a,
-    3px 0px 0 #333333,
-    5px -1px 0 #2a2a2a,
-    5px 0px 0 #333333;
   opacity: 0;
   animation: leg-toggle 0.25s steps(1) infinite reverse;
+  box-shadow:
+    4px -1px 0 #2a2a2a, 5px -1px 0 #2a2a2a;
 }
 
 @keyframes leg-toggle {
-  0% { opacity: 1; }
-  50% { opacity: 0; }
+  0%   { opacity: 1; }
+  50%  { opacity: 0; }
+  100% { opacity: 1; }
 }


### PR DESCRIPTION
## Summary
- **Fix countdown hours bug**: The timer was showing total hours (e.g. 77h) instead of remainder after days (e.g. 5h). Changed `total_seconds // 3600` to `(total_seconds % 86400) // 3600` to match the documented formula.
- **Add 8-bit pixel art hero animation**: Super Mario-style side-scroller with a chibi Caroline character (blonde hair, blue glasses, black turtleneck) running with a laptop, scrolling coral brick ground, parallax green hills, floating clouds, and a "let claude cook" speech bubble.

Closes #4

## Test plan
- [ ] Run `python3 -m pytest tests/ -v` — all 17 tests pass (including `test_hours_within_valid_range` and `test_countdown_multiple_days`)
- [ ] Open http://localhost:8000 and verify countdown shows hours in 0–23 range
- [ ] Verify the 8-bit animation renders between the countdown and the "Featuring" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)