### PR TITLE
Add capacity note to event data

### DIFF
--- a/webinar_site/data/event.json
+++ b/webinar_site/data/event.json
@@ -13,5 +13,6 @@
     "Live demo: code exploration, debugging, testing, and shipping commits"
   ],
   "cta_text": "Register Now",
-  "recording_note": "Can't make it? Register anyway — we'll send you the recording within 48 hours."
+  "recording_note": "Can't make it? Register anyway — we'll send you the recording within 48 hours.",
+  "capacity_note": "Space is limited — register early to secure your spot."
 }


### PR DESCRIPTION
## Summary
- Adds a "Space is limited — register early to secure your spot." note to `event.json`

## Test plan
- [ ] Verify `event.json` is valid JSON
- [ ] Check the note renders on the registration page

🤖 Generated with [Claude Code](https://claude.com/claude-code)